### PR TITLE
update_labels

### DIFF
--- a/composeApp/src/androidMain/assets/labels.txt
+++ b/composeApp/src/androidMain/assets/labels.txt
@@ -1,3 +1,14 @@
+chicken
+beef
+pork
+eggs
 carrot
 onion
 potato
+garlic
+spinach
+cucumber
+brocolli
+chilli
+aubergine
+salmon


### PR DESCRIPTION
### WHY
The labels used for ingredient detection do not reflect the latest changes.

### HOW
Update labels to the latest version.